### PR TITLE
Add Microsoft Clarity event tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import Script from "next/script";
+
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -11,9 +13,23 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const clarityId = process.env.NEXT_PUBLIC_CLARITY_ID;
+
   return (
     <html lang="ko">
       <body>
+        {clarityId ? (
+          <Script
+            id="clarity-script"
+            strategy="afterInteractive"
+          >{`
+            (function(c,l,a,r,i,t,y){
+              c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+              t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+              y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "${clarityId}");
+          `}</Script>
+        ) : null}
         {children}
 
         <svg style={{ display: 'none' }}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,13 +8,15 @@ import LinkPage from '@/components/Link';
 import FadeEffect from '@/components/Fade';
 import Nav from '@/components/Nav';
 import GlassEffect from "@/components/GlassEffect";
+import { trackClarityEvent } from "@/lib/clarity";
 
 const projects = ['ASCII Wave', 'Magnetic Packing', 'Glass Breaker'];
 const guides = [
   '눌러서 파동 만들기',
   '큰 원을 움직이기',
   '눌러서 유리 깨기'
-]
+];
+const sections = ["title", "about", "projects", "links"];
 
 export default function Home() {
   const [level, setLevel] = useState(0);
@@ -33,6 +35,13 @@ export default function Home() {
   useEffect(() => {
     setProjectNum(Math.floor(Math.random() * projects.length));
   }, []);
+
+  useEffect(() => {
+    trackClarityEvent("section:view", {
+      section: sections[level],
+      via: level === 0 ? "load" : "nav",
+    });
+  }, [level]);
 
   const changeComponent = (newLevel: number) => {
     setFadeState('fade-out');
@@ -54,8 +63,20 @@ export default function Home() {
       />}
       <div className={`absolute top-0 left-0 z-0 w-full h-full select-none pointer-events-none bg-black ${((level == 0) && (black == 'none'))? 'bg-opacity-0':'bg-opacity-70'} transition-all duration-500`}></div>
       <FadeEffect fadeState={fadeState}>{components[level]}</FadeEffect>
-      <Nav level={level} changeComponent={changeComponent} pages={components.length} direction="left"/>
-      <Nav level={level} changeComponent={changeComponent} pages={components.length} direction="right"/>
+      <Nav
+        level={level}
+        changeComponent={changeComponent}
+        pages={components.length}
+        direction="left"
+        sections={sections}
+      />
+      <Nav
+        level={level}
+        changeComponent={changeComponent}
+        pages={components.length}
+        direction="right"
+        sections={sections}
+      />
 
       <div className="fixed top-0 left-0 w-full h-full flex items-center justify-center pointer-events-none">
         <GlassEffect blurStdDev={4} maskScale={0.7} className=" top-10 z-10 text-white pointer-events-none">

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,11 +1,44 @@
-import React from "react";
+"use client";
+
+import React, { useRef } from "react";
 import Section from "./about/Section";
 import { educationData, exhibitionData, projectData } from "./about/data";
+import { trackClarityEvent } from "@/lib/clarity";
+
+const scrollDepths = [25, 50, 75, 100];
 
 const About = () => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const firedDepths = useRef<Set<number>>(new Set());
+
+  const handleScroll = () => {
+    const container = scrollRef.current;
+    if (!container) {
+      return;
+    }
+
+    const maxScroll = container.scrollHeight - container.clientHeight;
+    if (maxScroll <= 0) {
+      return;
+    }
+
+    const percent = Math.round((container.scrollTop / maxScroll) * 100);
+    scrollDepths.forEach((depth) => {
+      if (percent >= depth && !firedDepths.current.has(depth)) {
+        firedDepths.current.add(depth);
+        trackClarityEvent("about:scroll_depth", { depth });
+      }
+    });
+  };
+
   return (
     <div className="w-full h-full flex justify-center">
-      <div className="flex flex-col justify-start lg:justify-center w-[70vw] pt-[10vh] lg:pt-[14vh] text-white xl:overflow-y-visible overflow-y-scroll overscroll-none" style={{ WebkitOverflowScrolling: 'touch' }}>
+      <div
+        ref={scrollRef}
+        className="flex flex-col justify-start lg:justify-center w-[70vw] pt-[10vh] lg:pt-[14vh] text-white xl:overflow-y-visible overflow-y-scroll overscroll-none"
+        style={{ WebkitOverflowScrolling: 'touch' }}
+        onScroll={handleScroll}
+      >
         <div className="flex flex-col lg:flex-row justify-between items-center">
           <div className="flex flex-col lg:flex-row items-center">
             <img src="/images/orwiss.png" className="w-[150px] h-[150px] rounded-full"/>
@@ -14,7 +47,12 @@ const About = () => {
               <p className="text-md lg:text-xl mt-4">orwiss.design@gmail.com<br/>orwiss@kookmin.ac.kr</p>
             </div>
           </div>
-          <a href="https://orwiss.notion.site/6d45f80728b24b719db9c224bd68d6e1" target="_blank" className="relative">
+          <a
+            href="https://orwiss.notion.site/6d45f80728b24b719db9c224bd68d6e1"
+            target="_blank"
+            className="relative"
+            onClick={() => trackClarityEvent("cta:click", { target: "cv_page" })}
+          >
             <div className="absolute w-fit h-fit rounded-full px-8 py-5 mt-6 lg:mt-0 text-sm xl:text-xl text-transparent whitespace-nowrap bg-white/10 glassEffect">CV Page</div>
             <div className="w-fit h-fit px-8 py-5 mt-6 lg:mt-0 text-sm xl:text-xl whitespace-nowrap text-white rounded-full pointer-events-auto">
               CV Page

--- a/components/Link.tsx
+++ b/components/Link.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import React from 'react';
+import { trackClarityEvent } from '@/lib/clarity';
 
 type LinkType = {
   name: string;
@@ -34,6 +37,7 @@ const Link = () => {
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-center w-[clamp(200px,30%,320px)] h-16 md:h-20 rounded-full my-6 md:my-8 transition-transform transform hover:translate-y-[-4px] text-white text-lg font-bold text-center active:text-black pointer-events-auto"
+            onClick={() => trackClarityEvent("link:click", { target: link.name })}
           >
             <div className="absolute w-full h-full rounded-full bg-white/10 glassEffect"></div>
             <img

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,18 +1,26 @@
 import React from "react";
+import { trackClarityEvent } from "@/lib/clarity";
 
 interface NavProps {
   level: number;
   pages: number;
   changeComponent: (newLevel: number) => void;
   direction: "left" | "right";
+  sections: string[];
 }
 
-const NavButton: React.FC<NavProps> = ({ level, pages, changeComponent, direction }) => {
+const NavButton: React.FC<NavProps> = ({ level, pages, changeComponent, direction, sections }) => {
   const handleClick = () => {
     const newLevel = direction === "left" 
       ? (level - 1 + pages) % pages 
       : (level + 1) % pages;
-      
+
+    trackClarityEvent("nav:click", {
+      direction,
+      from_section: sections[level],
+      to_section: sections[newLevel],
+    });
+
     changeComponent(newLevel);
   };
 

--- a/lib/clarity.ts
+++ b/lib/clarity.ts
@@ -1,0 +1,23 @@
+"use client";
+
+type ClarityPayload = Record<string, string | number | boolean | null>;
+
+declare global {
+  interface Window {
+    clarity?: (...args: unknown[]) => void;
+  }
+}
+
+export const trackClarityEvent = (name: string, payload?: ClarityPayload) => {
+  if (!window.clarity) {
+    return;
+  }
+
+  if (payload) {
+    Object.entries(payload).forEach(([key, value]) => {
+      window.clarity?.("set", key, value);
+    });
+  }
+
+  window.clarity("event", name);
+};


### PR DESCRIPTION
### Motivation

- Integrate Microsoft Clarity to capture user interactions and behavior for product analytics and debugging.
- Only load the Clarity script when `NEXT_PUBLIC_CLARITY_ID` is configured to avoid tracking in development or when unset.
- Record SPA navigation and key user actions so engagement and scroll depth can be analyzed.

### Description

- Conditionally inject the Clarity script in `app/layout.tsx` using `Script` and the `NEXT_PUBLIC_CLARITY_ID` environment variable.
- Add a client-side helper `lib/clarity.ts` that exposes `trackClarityEvent(name, payload?)` and safely no-ops when `window.clarity` is unavailable.
- Instrument the main page flow in `app/page.tsx` to emit `section:view` events on section changes and pass a `sections` array into `Nav` for contextual events.
- Add event tracking to UI components: `nav:click` in `components/Nav.tsx`, `about:scroll_depth` and `cta:click` in `components/About.tsx`, and `link:click` in `components/Link.tsx`, with appropriate `use client` directives and scroll-depth deduplication logic.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969aef1a330832bb75814c39e6cdcf9)