### PR TITLE
Add route-based pages with persistent background

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,5 @@
+import About from "@/components/About";
+
+export default function AboutPage() {
+  return <About />;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Script from "next/script";
+import BackgroundShell from "@/components/BackgroundShell";
 
 import "./globals.css";
 
@@ -30,7 +31,7 @@ export default function RootLayout({
             })(window, document, "clarity", "script", "${clarityId}");
           `}</Script>
         ) : null}
-        {children}
+        <BackgroundShell>{children}</BackgroundShell>
 
         <svg style={{ display: 'none' }}>
           <filter id="container-glass" x="0%" y="0%" width="100%" height="100%">

--- a/app/link/page.tsx
+++ b/app/link/page.tsx
@@ -1,0 +1,5 @@
+import LinkPage from "@/components/Link";
+
+export default function LinkPage() {
+  return <LinkPage />;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,89 +1,19 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from "react";
-import Title from '@/components/Title';
-import About from '@/components/About';
-import Projects from '@/components/Notion';
-import LinkPage from '@/components/Link';
-import FadeEffect from '@/components/Fade';
-import Nav from '@/components/Nav';
-import GlassEffect from "@/components/GlassEffect";
-import { trackClarityEvent } from "@/lib/clarity";
+import Title from "@/components/Title";
+import { useBackground } from "@/components/BackgroundShell";
 
-const projects = ['ASCII Wave', 'Magnetic Packing', 'Glass Breaker'];
-const guides = [
-  '눌러서 파동 만들기',
-  '큰 원을 움직이기',
-  '눌러서 유리 깨기'
-];
-const sections = ["title", "about", "projects", "links"];
+const projects = ["ASCII Wave", "Magnetic Packing", "Glass Breaker"];
+const guides = ["눌러서 파동 만들기", "큰 원을 움직이기", "눌러서 유리 깨기"];
 
 export default function Home() {
-  const [level, setLevel] = useState(0);
-  const [fadeState, setFadeState] = useState<'fade-in' | 'fade-out'>('fade-in');
-  const [black, setBlack] = useState<'black' | 'none'>('black');
-  const [projectNum, setProjectNum] = useState<number | null>(null);
-  const blackOff = () => setBlack('none');
-
-  const components = [
-    <Title key={0} titleText={projectNum !== null? projects[projectNum]:''} guideText={projectNum !== null? guides[projectNum]:''} blackoff={blackOff}/>, 
-    <About key={1}/>, 
-    <Projects key={2}/>, 
-    <LinkPage key={3}/>
-  ];
-
-  useEffect(() => {
-    setProjectNum(Math.floor(Math.random() * projects.length));
-  }, []);
-
-  useEffect(() => {
-    trackClarityEvent("section:view", {
-      section: sections[level],
-      via: level === 0 ? "load" : "nav",
-    });
-  }, [level]);
-
-  const changeComponent = (newLevel: number) => {
-    setFadeState('fade-out');
-    setTimeout(() => {
-      setLevel(newLevel);
-      setBlack('black');
-      setFadeState('fade-in');
-    }, 500);
-  };
+  const { blackOff, projectNum } = useBackground();
 
   return (
-    <div className="relative h-dvh text-white bg-black overflow-hidden overscroll-none">
-      {projectNum !== null && <iframe
-        key={`${projectNum + 1}`}
-        src={`/sketches/sketch${projectNum + 1}/index.html`}
-        className='absolute top-0 left-0 z-0 w-full h-full border-none'
-        title="background sketch"
-        {... (projectNum + 1 === 3 ? { allow: 'accelerometer; gyroscope;' } : {})}
-      />}
-      <div className={`absolute top-0 left-0 z-0 w-full h-full select-none pointer-events-none bg-black ${((level == 0) && (black == 'none'))? 'bg-opacity-0':'bg-opacity-70'} transition-all duration-500`}></div>
-      <FadeEffect fadeState={fadeState}>{components[level]}</FadeEffect>
-      <Nav
-        level={level}
-        changeComponent={changeComponent}
-        pages={components.length}
-        direction="left"
-        sections={sections}
-      />
-      <Nav
-        level={level}
-        changeComponent={changeComponent}
-        pages={components.length}
-        direction="right"
-        sections={sections}
-      />
-
-      <div className="fixed top-0 left-0 w-full h-full flex items-center justify-center pointer-events-none">
-        <GlassEffect blurStdDev={4} maskScale={0.7} className=" top-10 z-10 text-white pointer-events-none">
-          <div></div>
-        </GlassEffect>
-      </div>
-      
-    </div>
+    <Title
+      titleText={projectNum !== null ? projects[projectNum] : ""}
+      guideText={projectNum !== null ? guides[projectNum] : ""}
+      blackoff={blackOff}
+    />
   );
 }

--- a/app/project/page.tsx
+++ b/app/project/page.tsx
@@ -1,0 +1,5 @@
+import Projects from "@/components/Notion";
+
+export default function ProjectPage() {
+  return <Projects />;
+}

--- a/components/BackgroundShell.tsx
+++ b/components/BackgroundShell.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import FadeEffect from "@/components/Fade";
+import Nav from "@/components/Nav";
+import GlassEffect from "@/components/GlassEffect";
+import { trackClarityEvent } from "@/lib/clarity";
+
+type BackgroundContextValue = {
+  blackOff: () => void;
+  projectNum: number | null;
+};
+
+const BackgroundContext = createContext<BackgroundContextValue>({
+  blackOff: () => {},
+  projectNum: null,
+});
+
+export const useBackground = () => useContext(BackgroundContext);
+
+const projects = ["ASCII Wave", "Magnetic Packing", "Glass Breaker"];
+const sections = ["title", "about", "project", "link"];
+const routes = ["/", "/about", "/project", "/link"];
+
+const getLevelFromPath = (pathname: string) => {
+  const index = routes.indexOf(pathname);
+  return index === -1 ? 0 : index;
+};
+
+export default function BackgroundShell({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [level, setLevel] = useState(() => getLevelFromPath(pathname));
+  const [fadeState, setFadeState] = useState<"fade-in" | "fade-out">("fade-in");
+  const [black, setBlack] = useState<"black" | "none">("black");
+  const [projectNum, setProjectNum] = useState<number | null>(null);
+  const initialLoad = useRef(true);
+
+  useEffect(() => {
+    setProjectNum(Math.floor(Math.random() * projects.length));
+  }, []);
+
+  useEffect(() => {
+    const newLevel = getLevelFromPath(pathname);
+    setLevel(newLevel);
+    setBlack("black");
+
+    trackClarityEvent("section:view", {
+      section: sections[newLevel],
+      via: initialLoad.current ? "load" : "nav",
+    });
+
+    initialLoad.current = false;
+  }, [pathname]);
+
+  const changeComponent = (newLevel: number) => {
+    setFadeState("fade-out");
+    setTimeout(() => {
+      router.push(routes[newLevel]);
+      setFadeState("fade-in");
+    }, 500);
+  };
+
+  return (
+    <BackgroundContext.Provider
+      value={{
+        blackOff: () => setBlack("none"),
+        projectNum,
+      }}
+    >
+      <div className="relative h-dvh text-white bg-black overflow-hidden overscroll-none">
+        {projectNum !== null && (
+          <iframe
+            key={`${projectNum + 1}`}
+            src={`/sketches/sketch${projectNum + 1}/index.html`}
+            className="absolute top-0 left-0 z-0 w-full h-full border-none"
+            title="background sketch"
+            {...(projectNum + 1 === 3 ? { allow: "accelerometer; gyroscope;" } : {})}
+          />
+        )}
+        <div
+          className={`absolute top-0 left-0 z-0 w-full h-full select-none pointer-events-none bg-black ${
+            level === 0 && black === "none" ? "bg-opacity-0" : "bg-opacity-70"
+          } transition-all duration-500`}
+        ></div>
+        <FadeEffect fadeState={fadeState}>{children}</FadeEffect>
+        <Nav
+          level={level}
+          changeComponent={changeComponent}
+          pages={routes.length}
+          direction="left"
+          sections={sections}
+        />
+        <Nav
+          level={level}
+          changeComponent={changeComponent}
+          pages={routes.length}
+          direction="right"
+          sections={sections}
+        />
+
+        <div className="fixed top-0 left-0 w-full h-full flex items-center justify-center pointer-events-none">
+          <GlassEffect blurStdDev={4} maskScale={0.7} className=" top-10 z-10 text-white pointer-events-none">
+            <div></div>
+          </GlassEffect>
+        </div>
+      </div>
+    </BackgroundContext.Provider>
+  );
+}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { trackClarityEvent } from "@/lib/clarity";
 


### PR DESCRIPTION
### Motivation

- Preserve the existing background canvas, navigation, and transitions so the visual background does not reload during navigation. 
- Split the single-page UI into route-based pages to leverage Next.js routing for `/about`, `/project`, and `/link` while keeping the shared background persistent. 
- Expose shared background state (random sketch selection and overlay control) so page components such as the title can consume it.

### Description

- Add `components/BackgroundShell.tsx` which provides a `BackgroundContext` (`useBackground`) and renders the persistent iframe sketch, black overlay, `Fade` wrapper, `Nav` buttons, and `GlassEffect`, and handles route-aware transitions with `usePathname`/`useRouter` and `trackClarityEvent`.
- Wrap all pages with the background shell by embedding `<BackgroundShell>{children}</BackgroundShell>` in `app/layout.tsx` so the background persists across route transitions.
- Convert the previous inlined title/home logic into a consumer of the new context by updating `app/page.tsx` to call `useBackground` and render `Title` with `projectNum` and `blackoff` from the shell.
- Add route entry points `app/about/page.tsx`, `app/project/page.tsx`, and `app/link/page.tsx` which mount the existing `About`, `Notion` (Projects), and `Link` components respectively, and mark `components/Nav.tsx` as a client component (`"use client"`).

### Testing

- Attempted to install dependencies with `npm install`, which failed with a `403 Forbidden` error while fetching packages, so the application could not be started and no automated tests were run.
- No other automated test runs succeeded due to the dependency install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969d58ea8a8832bae334a0f0a7e5e26)