### PR TITLE
Trigger section swap on fade completion and add Clarity analytics instrumentation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+
+import ClarityProvider from "@/components/ClarityProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -14,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
+        <ClarityProvider />
         {children}
 
         <svg style={{ display: 'none' }}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,19 +8,23 @@ import LinkPage from '@/components/Link';
 import FadeEffect from '@/components/Fade';
 import Nav from '@/components/Nav';
 import GlassEffect from "@/components/GlassEffect";
+import { trackClarityEvent } from "@/lib/clarity";
 
 const projects = ['ASCII Wave', 'Magnetic Packing', 'Glass Breaker'];
 const guides = [
   '눌러서 파동 만들기',
   '큰 원을 움직이기',
   '눌러서 유리 깨기'
-]
+];
+const sections = ["title", "about", "projects", "links"];
 
 export default function Home() {
   const [level, setLevel] = useState(0);
   const [fadeState, setFadeState] = useState<'fade-in' | 'fade-out'>('fade-in');
   const [black, setBlack] = useState<'black' | 'none'>('black');
   const [projectNum, setProjectNum] = useState<number | null>(null);
+  const [pendingLevel, setPendingLevel] = useState<number | null>(null);
+  const [isTransitioning, setIsTransitioning] = useState(false);
   const blackOff = () => setBlack('none');
 
   const components = [
@@ -34,13 +38,40 @@ export default function Home() {
     setProjectNum(Math.floor(Math.random() * projects.length));
   }, []);
 
+  useEffect(() => {
+    trackClarityEvent("section:view", {
+      section: sections[level],
+      via: level === 0 ? "load" : "nav",
+    });
+  }, [level]);
+
   const changeComponent = (newLevel: number) => {
+    if (isTransitioning || newLevel === level) {
+      return;
+    }
+
+    setPendingLevel(newLevel);
+    setIsTransitioning(true);
     setFadeState('fade-out');
-    setTimeout(() => {
-      setLevel(newLevel);
-      setBlack('black');
-      setFadeState('fade-in');
-    }, 500);
+  };
+
+  const handleFadeOutComplete = () => {
+    if (fadeState !== 'fade-out' || pendingLevel === null) {
+      return;
+    }
+
+    setLevel(pendingLevel);
+    setPendingLevel(null);
+    setBlack('black');
+    setFadeState('fade-in');
+  };
+
+  const handleFadeInComplete = () => {
+    if (fadeState !== 'fade-in') {
+      return;
+    }
+
+    setIsTransitioning(false);
   };
 
   return (
@@ -53,9 +84,27 @@ export default function Home() {
         {... (projectNum + 1 === 3 ? { allow: 'accelerometer; gyroscope;' } : {})}
       />}
       <div className={`absolute top-0 left-0 z-0 w-full h-full select-none pointer-events-none bg-black ${((level == 0) && (black == 'none'))? 'bg-opacity-0':'bg-opacity-70'} transition-all duration-500`}></div>
-      <FadeEffect fadeState={fadeState}>{components[level]}</FadeEffect>
-      <Nav level={level} changeComponent={changeComponent} pages={components.length} direction="left"/>
-      <Nav level={level} changeComponent={changeComponent} pages={components.length} direction="right"/>
+      <FadeEffect
+        fadeState={fadeState}
+        onFadeOutComplete={handleFadeOutComplete}
+        onFadeInComplete={handleFadeInComplete}
+      >
+        {components[level]}
+      </FadeEffect>
+      <Nav
+        level={level}
+        changeComponent={changeComponent}
+        pages={components.length}
+        direction="left"
+        sections={sections}
+      />
+      <Nav
+        level={level}
+        changeComponent={changeComponent}
+        pages={components.length}
+        direction="right"
+        sections={sections}
+      />
 
       <div className="fixed top-0 left-0 w-full h-full flex items-center justify-center pointer-events-none">
         <GlassEffect blurStdDev={4} maskScale={0.7} className=" top-10 z-10 text-white pointer-events-none">

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,11 +1,44 @@
-import React from "react";
+"use client";
+
+import React, { useRef } from "react";
 import Section from "./about/Section";
 import { educationData, exhibitionData, projectData } from "./about/data";
+import { trackClarityEvent } from "@/lib/clarity";
+
+const scrollDepths = [25, 50, 75, 100];
 
 const About = () => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const firedDepths = useRef<Set<number>>(new Set());
+
+  const handleScroll = () => {
+    const container = scrollRef.current;
+    if (!container) {
+      return;
+    }
+
+    const maxScroll = container.scrollHeight - container.clientHeight;
+    if (maxScroll <= 0) {
+      return;
+    }
+
+    const percent = Math.round((container.scrollTop / maxScroll) * 100);
+    scrollDepths.forEach((depth) => {
+      if (percent >= depth && !firedDepths.current.has(depth)) {
+        firedDepths.current.add(depth);
+        trackClarityEvent("about:scroll_depth", { depth });
+      }
+    });
+  };
+
   return (
     <div className="w-full h-full flex justify-center">
-      <div className="flex flex-col justify-start lg:justify-center w-[70vw] pt-[10vh] lg:pt-[14vh] text-white xl:overflow-y-visible overflow-y-scroll overscroll-none" style={{ WebkitOverflowScrolling: 'touch' }}>
+      <div
+        ref={scrollRef}
+        className="flex flex-col justify-start lg:justify-center w-[70vw] pt-[10vh] lg:pt-[14vh] text-white xl:overflow-y-visible overflow-y-scroll overscroll-none"
+        style={{ WebkitOverflowScrolling: 'touch' }}
+        onScroll={handleScroll}
+      >
         <div className="flex flex-col lg:flex-row justify-between items-center">
           <div className="flex flex-col lg:flex-row items-center">
             <img src="/images/orwiss.png" className="w-[150px] h-[150px] rounded-full"/>
@@ -14,7 +47,12 @@ const About = () => {
               <p className="text-md lg:text-xl mt-4">orwiss.design@gmail.com<br/>orwiss@kookmin.ac.kr</p>
             </div>
           </div>
-          <a href="https://orwiss.notion.site/6d45f80728b24b719db9c224bd68d6e1" target="_blank" className="relative">
+          <a
+            href="https://orwiss.notion.site/6d45f80728b24b719db9c224bd68d6e1"
+            target="_blank"
+            className="relative"
+            onClick={() => trackClarityEvent("cta:click", { target: "cv_page" })}
+          >
             <div className="absolute w-fit h-fit rounded-full px-8 py-5 mt-6 lg:mt-0 text-sm xl:text-xl text-transparent whitespace-nowrap bg-white/10 glassEffect">CV Page</div>
             <div className="w-fit h-fit px-8 py-5 mt-6 lg:mt-0 text-sm xl:text-xl whitespace-nowrap text-white rounded-full pointer-events-auto">
               CV Page

--- a/components/ClarityProvider.tsx
+++ b/components/ClarityProvider.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+import { initClarity } from "@/lib/clarity";
+
+export default function ClarityProvider() {
+  useEffect(() => {
+    const clarityId = process.env.NEXT_PUBLIC_CLARITY_ID;
+    if (!clarityId) {
+      return;
+    }
+
+    initClarity(clarityId);
+  }, []);
+
+  return null;
+}

--- a/components/Fade.tsx
+++ b/components/Fade.tsx
@@ -5,11 +5,27 @@ import { ReactNode } from "react";
 interface FadeProps {
   fadeState: 'fade-in' | 'fade-out'
   children: ReactNode;
+  onFadeOutComplete?: () => void;
+  onFadeInComplete?: () => void;
 }
 
-export default function FadeEffect({ fadeState, children }: FadeProps) {
+export default function FadeEffect({
+  fadeState,
+  children,
+  onFadeOutComplete,
+  onFadeInComplete,
+}: FadeProps) {
   return (
-    <div className={`relative z-10 w-full h-full select-none pointer-events-none transition-opacity duration-500 ${fadeState === 'fade-out'? 'opacity-0':'opacity-100'}`}>
+    <div
+      className={`relative z-10 w-full h-full select-none pointer-events-none transition-opacity duration-500 ${fadeState === 'fade-out'? 'opacity-0':'opacity-100'}`}
+      onTransitionEnd={() => {
+        if (fadeState === 'fade-out') {
+          onFadeOutComplete?.();
+        } else {
+          onFadeInComplete?.();
+        }
+      }}
+    >
       {children}
     </div>
   )

--- a/components/Link.tsx
+++ b/components/Link.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import React from 'react';
+import { trackClarityEvent } from '@/lib/clarity';
 
 type LinkType = {
   name: string;
@@ -34,6 +37,7 @@ const Link = () => {
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-center w-[clamp(200px,30%,320px)] h-16 md:h-20 rounded-full my-6 md:my-8 transition-transform transform hover:translate-y-[-4px] text-white text-lg font-bold text-center active:text-black pointer-events-auto"
+            onClick={() => trackClarityEvent("link:click", { target: link.name })}
           >
             <div className="absolute w-full h-full rounded-full bg-white/10 glassEffect"></div>
             <img

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,18 +1,26 @@
 import React from "react";
+import { trackClarityEvent } from "@/lib/clarity";
 
 interface NavProps {
   level: number;
   pages: number;
   changeComponent: (newLevel: number) => void;
   direction: "left" | "right";
+  sections: string[];
 }
 
-const NavButton: React.FC<NavProps> = ({ level, pages, changeComponent, direction }) => {
+const NavButton: React.FC<NavProps> = ({ level, pages, changeComponent, direction, sections }) => {
   const handleClick = () => {
     const newLevel = direction === "left" 
       ? (level - 1 + pages) % pages 
       : (level + 1) % pages;
-      
+
+    trackClarityEvent("nav:click", {
+      direction,
+      from_section: sections[level],
+      to_section: sections[newLevel],
+    });
+
     changeComponent(newLevel);
   };
 

--- a/lib/clarity.ts
+++ b/lib/clarity.ts
@@ -1,0 +1,79 @@
+"use client";
+
+type ClarityPayload = Record<string, string | number | boolean | null>;
+
+type ClarityModule = {
+  default?: ClarityClient;
+  start?: (options: { projectId: string }) => void;
+  set?: (key: string, value: string | number | boolean | null) => void;
+  event?: (name: string) => void;
+};
+
+type ClarityClient = {
+  start?: (options: { projectId: string }) => void;
+  set?: (key: string, value: string | number | boolean | null) => void;
+  event?: (name: string) => void;
+};
+
+declare global {
+  interface Window {
+    clarity?: (...args: unknown[]) => void;
+  }
+}
+
+let clarityClient: ClarityClient | null = null;
+
+const resolveClient = (module: ClarityModule): ClarityClient => {
+  if (module.default) {
+    return module.default;
+  }
+
+  return module;
+};
+
+export const initClarity = async (projectId: string) => {
+  if (clarityClient) {
+    return;
+  }
+
+  try {
+    const module = (await import("@microsoft/clarity")) as ClarityModule;
+    const client = resolveClient(module);
+
+    if (client.start) {
+      client.start({ projectId });
+      clarityClient = client;
+      return;
+    }
+  } catch {
+    // fallback to window clarity when the package is unavailable
+  }
+
+  if (window.clarity) {
+    window.clarity("start", { projectId });
+  }
+};
+
+export const trackClarityEvent = (name: string, payload?: ClarityPayload) => {
+  const eventTarget = clarityClient;
+
+  if (!eventTarget && !window.clarity) {
+    return;
+  }
+
+  if (payload) {
+    Object.entries(payload).forEach(([key, value]) => {
+      if (eventTarget?.set) {
+        eventTarget.set(key, value);
+      } else {
+        window.clarity?.("set", key, value);
+      }
+    });
+  }
+
+  if (eventTarget?.event) {
+    eventTarget.event(name);
+  } else {
+    window.clarity?.("event", name);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@microsoft/clarity": "^1.0.0",
     "@notionhq/client": "^2.2.15",
     "@upstash/redis": "^1.34.8",
     "next": "14.2.35",


### PR DESCRIPTION
### Motivation
- Fix fragile section-switch timing that previously relied on a fixed `setTimeout` and allowed repeated transitions while a fade was running.
- Provide reliable fade lifecycle hooks so UI can swap content exactly when the fade-out finishes.
- Add optional Microsoft Clarity analytics initialization and event tracking so user interactions and navigation can be recorded when `NEXT_PUBLIC_CLARITY_ID` is configured.

### Description
- Add `onFadeOutComplete` and `onFadeInComplete` callbacks to `components/Fade.tsx` and call them from the CSS transition `onTransitionEnd` handler.
- Replace the `setTimeout`-based swap in `app/page.tsx` with `pendingLevel`/`isTransitioning` state and `handleFadeOutComplete`/`handleFadeInComplete` handlers, and wire the `FadeEffect` callbacks to ensure a single, race-free transition flow.
- Add Clarity initialization and tracking: create `components/ClarityProvider.tsx` and `lib/clarity.ts`, import and mount `ClarityProvider` from `app/layout.tsx`, and add a safe `trackClarityEvent` API that falls back to `window.clarity` when the package is not available.
- Instrument events: track `section:view` in `app/page.tsx`, `nav:click` in `components/Nav.tsx`, `about:scroll_depth` and `cta:click` in `components/About.tsx`, and `link:click` in `components/Link.tsx`.
- Add `@microsoft/clarity` to `package.json` so the package will be installed when used.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969aef1a330832bb75814c39e6cdcf9)